### PR TITLE
Hide toolbar when zoomed in

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -190,6 +190,10 @@ html.noscroll {
 	z-index: 100;
 }
 
+/* Quickfix - hide toolbar when zoomed */
+.js-zoomed .toolbar {
+	display: none;
+}
 
 /* ====================================================*/
 /* Full height images toggle */


### PR DESCRIPTION
Hide toolbar once image is zoomed in - it no longer functions and overlaps the caption
